### PR TITLE
feat(runner): return patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm run build:python # Python
 
 ## Usage
 
+### CLI
+
 ```bash
 npm run debug ./path/to/file(.c|.cpp|.php|.py)
 
@@ -37,6 +39,53 @@ npm run debug ./samples/cpp/hello_world.cpp # For C++
 npm run debug ./samples/php/hello_world.php # For PHP
 npm run debug ./samples/python/hello_world.py # For Python
 ```
+
+### Programmatical
+
+```ts
+import { callScript } from 'codecast-debuggers' // if package is published :shrug:
+
+callScript(filePath, 'off').then(rawJSON => {
+  const steps = JSON.parse(rawJSON) as Steps
+  // …
+}).catch(error => {
+  // handle that
+});
+```
+
+### Reconstruct snapshot of each step from patches
+
+```ts
+// Produced result:
+import { type Patch, applyPatches, enablePatches } from 'immer'
+type Step = Patch[] // a step is a list of patch to apply
+
+// This is the result you obtain after calling the script
+type Result = Step[]
+
+// The step snapshot type represents a step in its constructed (not patched) form
+type StepSnapshot = {
+  stackFrames: Array<DebugProtocol.StackFrame & {
+    scopes: Array<DebugProtocol.Scope & {
+      variables: Array<DebugProtocol.Variable & {
+        variables: DebugProtocol.Variable & … // recursive type
+      }>
+    }>
+  }>,
+}
+
+enablePatches();
+function reconstructSnapshotsFromSteps(steps: Step[]): StepSnapshot[] {
+  return steps.reduce((acc, patches) => {
+    const previous = acc[acc.length-1] ?? {};
+    const snapshot = applyPatches(previous, patches) as StepSnapshot;
+    acc.push(snapshot);
+    return acc;
+  }, [] as StepSnapshot[]);
+}
+```
+
+---
 
 ## Re-install LLDB debug adapter server (C/C++ debug adapter)
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ npm run debug ./samples/python/hello_world.py # For Python
 ```ts
 import { callScript } from 'codecast-debuggers' // if package is published :shrug:
 
-callScript(filePath, 'off').then(rawJSON => {
+callScript(filePath).then(rawJSON => {
   const steps = JSON.parse(rawJSON) as Steps
   // …
 }).catch(error => {
-  // handle that
+  // silence is golden.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ type StepSnapshot = {
   stackFrames: Array<DebugProtocol.StackFrame & {
     scopes: Array<DebugProtocol.Scope & {
       variables: Array<DebugProtocol.Variable & {
-        variables: DebugProtocol.Variable & … // recursive type
+        variables: Array<DebugProtocol.Variable & …> // recursive type
       }>
     }>
   }>,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "node-debugprotocol-client": "^0.5.0"
+        "immer": "^9.0.12",
+        "node-debugprotocol-client": "^0.5.0",
+        "recursive-diff": "^1.0.8"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
@@ -2847,6 +2849,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4332,6 +4343,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/recursive-diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/recursive-diff/-/recursive-diff-1.0.8.tgz",
+      "integrity": "sha512-WfUcVao/HRsZZjI96PjcefTZ87rsxrgryIlWJB2UrHs4v3kFFzvMOm801a1WoqG+IAsLKJPsGlvubR74EDqGWQ=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -7382,6 +7398,11 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immer": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -8519,6 +8540,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "recursive-diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/recursive-diff/-/recursive-diff-1.0.8.tgz",
+      "integrity": "sha512-WfUcVao/HRsZZjI96PjcefTZ87rsxrgryIlWJB2UrHs4v3kFFzvMOm801a1WoqG+IAsLKJPsGlvubR74EDqGWQ=="
     },
     "regexpp": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "codecast-debuggers",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "out/call-script.js",
   "scripts": {
     "build:ts": "tsc",
     "build:lldb": "docker build -f ./LLDB_Dockerfile . -t lldb-debugger",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:python": "docker build -f ./Python_Dockerfile . -t python-debugger",
     "debug": "node out/debug.js",
     "lint": "eslint src",
+    "pretest": "npm run build:ts",
     "test": "jest src/"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "license": "ISC",
   "// type": "module",
   "dependencies": {
-    "node-debugprotocol-client": "^0.5.0"
+    "immer": "^9.0.12",
+    "node-debugprotocol-client": "^0.5.0",
+    "recursive-diff": "^1.0.8"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/src/call-script.spec.ts
+++ b/src/call-script.spec.ts
@@ -1,11 +1,11 @@
 import { callScript } from './call-script';
 import { applyPatches, Patch, enablePatches } from 'immer';
-import { StepSnapshot } from './run-steps/runner';
+import { Steps, StepSnapshot } from './run-steps/runner';
 
 enablePatches();
 
 describe('callScript()', () => {
-  function reconstructResultFromSteps(steps: Patch[][]): StepSnapshot[] {
+  function reconstructResultFromSteps(steps: Steps): StepSnapshot[] {
     return steps.reduce((acc, patches) => {
       const previous = acc[acc.length-1] ?? {};
       const snapshot = applyPatches(previous, patches) as StepSnapshot;

--- a/src/call-script.spec.ts
+++ b/src/call-script.spec.ts
@@ -1,5 +1,5 @@
 import { callScript } from './call-script';
-import { applyPatches, Patch, enablePatches } from 'immer';
+import { applyPatches, enablePatches } from 'immer';
 import { Steps, StepSnapshot } from './run-steps/runner';
 
 enablePatches();
@@ -22,7 +22,7 @@ describe('callScript()', () => {
     // './samples/php/hello_world.php',
   ])('should match snapshot for %s', async fileRelativePath => {
     const stringified = await callScript(fileRelativePath, 'off');
-    const steps = JSON.parse(stringified) as Patch[][];
+    const steps = JSON.parse(stringified) as Steps;
     const result = reconstructResultFromSteps(steps);
     expect(result).toMatchSnapshot();
   });

--- a/src/call-script.spec.ts
+++ b/src/call-script.spec.ts
@@ -1,6 +1,19 @@
 import { callScript } from './call-script';
+import { applyPatches, Patch, enablePatches } from 'immer';
+import { StepSnapshot } from './run-steps/runner';
+
+enablePatches();
 
 describe('callScript()', () => {
+  function reconstructResultFromSteps(steps: Patch[][]): StepSnapshot[] {
+    return steps.reduce((acc, patches) => {
+      const previous = acc[acc.length-1] ?? {};
+      const snapshot = applyPatches(previous, patches) as StepSnapshot;
+      acc.push(snapshot);
+      return acc;
+    }, [] as StepSnapshot[]);
+  }
+
   it.each([
     './samples/c/hello_world.c',
     './samples/cpp/function_rec.cpp',
@@ -9,6 +22,8 @@ describe('callScript()', () => {
     // './samples/php/hello_world.php',
   ])('should match snapshot for %s', async fileRelativePath => {
     const stringified = await callScript(fileRelativePath, 'off');
-    expect(JSON.parse(stringified)).toMatchSnapshot();
+    const steps = JSON.parse(stringified) as Patch[][];
+    const result = reconstructResultFromSteps(steps);
+    expect(result).toMatchSnapshot();
   });
 });

--- a/src/run-steps/runner.ts
+++ b/src/run-steps/runner.ts
@@ -1,6 +1,8 @@
 import cp from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { getDiff, rdiffResult as PatchDiff } from 'recursive-diff';
+import { Patch } from 'immer';
 import { LogLevel, SocketDebugClient, Unsubscribable } from 'node-debugprotocol-client';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { logger } from '../logger';
@@ -71,10 +73,13 @@ export const makeRunner = ({
   canDigVariable = (): boolean => true,
 }: MakeRunnerConfig): Runner => {
   const destroyed = false;
-  const stepsAcc: Steps = [];
+  const acc: StepsAcc = {
+    previous: null,
+    patches: [],
+  };
   let resolveSteps: () => void = () => {};
-  const steps = new Promise<Steps>(resolve => {
-    resolveSteps = (): void => resolve(stepsAcc);
+  const steps = new Promise<StepsAcc>(resolve => {
+    resolveSteps = (): void => resolve(acc);
   });
   return async (options: RunnerOptions) => {
     const processes: cp.ChildProcess[] = [];
@@ -119,7 +124,7 @@ export const makeRunner = ({
       if (!reasons.includes(stoppedEvent.reason) || typeof stoppedEvent.threadId !== 'number') return;
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       setSnapshotAndStepIn({
-        stepsAcc,
+        acc,
         filePaths: [ options.main, ...options.files ].map(file => path.resolve(process.cwd(), file.relativePath)),
         context: { client, canDigScope, canDigVariable },
         threadId: stoppedEvent.threadId,
@@ -136,11 +141,7 @@ export const makeRunner = ({
 
     logger.debug(4, '[runner] await steps');
     const result = await steps;
-    const filtered = result.map(snapshot => ({
-      ...snapshot,
-      stackFrames: snapshot.stackFrames.filter(frame => frame.source?.path === programPath),
-    })).filter(({ stackFrames }) => stackFrames.length > 0);
-    logger.dir({ steps: filtered }, { colors: true, depth: 20 });
+    logger.dir({ steps }, { colors: true, depth: 20 });
 
     logger.debug(5, '[runner] destroy');
     try {
@@ -150,10 +151,23 @@ export const makeRunner = ({
     }
 
     logger.debug(6, '[runner] return result');
-    return result;
+    return result.patches;
   };
 };
-export type Steps = StepSnapshot[];
+
+export type Steps = StepsAcc['patches'];
+
+export interface StepsAcc {
+  /**
+   * previous snapshot, `null` only at first step (step 0)
+   */
+  previous: StepSnapshot | null,
+  /**
+   * Patch list per step
+   * Each patch list is computed from previous step and *not* from start.
+   */
+  patches: Patch[][], // Patches _per step based on previous step_
+}
 export interface StepSnapshot {
   stackFrames: StackFrame[],
 }
@@ -254,7 +268,7 @@ interface SetSnapshotAndStepInParams {
   /**
    * Accumulator to push steps to. Must be an original (not cloned) mutable array
    */
-  stepsAcc: Steps,
+  acc: StepsAcc,
   /**
    * absolute paths
    */
@@ -262,13 +276,19 @@ interface SetSnapshotAndStepInParams {
   context: RunStepContext,
   threadId: GetSnapshotParams['threadId'],
 }
-async function setSnapshotAndStepIn({ context, stepsAcc, filePaths, threadId }: SetSnapshotAndStepInParams): Promise<void> {
-  const i = stepsAcc.length;
+async function setSnapshotAndStepIn({ context, acc, filePaths, threadId }: SetSnapshotAndStepInParams): Promise<void> {
+  const i = acc.previous === null ? 1 : acc.patches.length + 2;
   try {
     logger.debug('Execute steps', i);
     const snapshot = await getSnapshot({ context, filePaths, threadId });
     logger.dir({ snapshot }, { colors: true, depth: 10 });
-    if (snapshot.stackFrames.length > 0) stepsAcc.push(snapshot);
+
+    if (snapshot.stackFrames.length > 0) {
+      const diff = getDiff(acc.previous, snapshot);
+      acc.patches.push(diff.map(recursiveDiffPatchToImmerPatch));
+      acc.previous = snapshot; // set base for next step
+    }
+
     snapshot.stackFrames.some(isStackFrameOfSourceFile(filePaths))
       ? await context.client.stepIn({ threadId, granularity: 'instruction' })
       : await context.client.stepOut({ threadId, granularity: 'instruction' });
@@ -353,4 +373,17 @@ async function getVariable({ context, maxDepth, variable }: GetVariableParams, c
 function isStackFrameOfSourceFile(fileAbsolutePaths: string[]) {
   return (stackFrame: DebugProtocol.StackFrame): boolean =>
     !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path);
+}
+
+function recursiveDiffPatchToImmerPatch(patch: PatchDiff): Patch {
+  const opAdapter: Record<PatchDiff['op'], Patch['op']> = {
+    add: 'add',
+    delete: 'remove',
+    update: 'replace',
+  };
+  return {
+    op: opAdapter[patch.op],
+    path: patch.path,
+    value: patch.val, // eslint-disable-line
+  };
 }

--- a/src/run-steps/runner.ts
+++ b/src/run-steps/runner.ts
@@ -298,7 +298,6 @@ async function setSnapshotAndStepIn({ context, acc, filePaths, threadId }: SetSn
         draft => void applyDiff(draft, diff),
         patches => void acc.steps.push(patches),
       );
-      // acc.steps.push(diff.map(recursiveDiffPatchToImmerPatch))
       acc.previous = snapshot; // set base for next step
     }
 
@@ -387,16 +386,3 @@ function isStackFrameOfSourceFile(fileAbsolutePaths: string[]) {
   return (stackFrame: DebugProtocol.StackFrame): boolean =>
     !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path);
 }
-
-// function recursiveDiffPatchToImmerPatch(patch: PatchDiff): Patch {
-//   const opAdapter: Record<PatchDiff['op'], Patch['op']> = {
-//     add: 'add',
-//     delete: 'remove',
-//     update: 'replace',
-//   }
-//   return {
-//     op: opAdapter[patch.op],
-//     path: patch.path,
-//     ...(patch.val && { value: patch.val }),
-//   }
-// }

--- a/src/run-steps/runner.ts
+++ b/src/run-steps/runner.ts
@@ -162,12 +162,11 @@ export type Steps = Step[];
 
 export interface StepsAcc {
   /**
-   * previous snapshot, `null` only at first step (step 0)
+   * previous snapshot, `{}` only at first step
    */
   previous: Partial<StepSnapshot>,
   /**
-   * Patch list per step
-   * Each patch list is computed from previous step and *not* from start.
+   * A step is a list of patches computed from previous step and *not* from start
    */
   steps: Steps, // Patches _per step based on previous step_
 }
@@ -280,7 +279,7 @@ interface SetSnapshotAndStepInParams {
   threadId: GetSnapshotParams['threadId'],
 }
 async function setSnapshotAndStepIn({ context, acc, filePaths, threadId }: SetSnapshotAndStepInParams): Promise<void> {
-  const i = acc.previous === null ? 1 : acc.steps.length + 2;
+  const i = acc.steps.length + 1;
   try {
     logger.debug('Execute steps', i);
     const snapshot = await getSnapshot({ context, filePaths, threadId });


### PR DESCRIPTION
Fixes #3 

Note: I ended up using [recursive-diff](https://www.npmjs.com/package/recursive-diff) because it allows to explicitly compute the diff between two objects while immer allows to deduce patches from deep object mutations.
Then the patches are converted to the ImmerJS patch type.
In case of change of mind, `recursive-diff` is 2kB minified and could be ported easily to a frontend app.

The result is interesting:
When parsing [function_rec.cpp](https://github.com/France-ioi/codecast-debuggers/blob/master/samples/cpp/function_rec.cpp), result is (minified sizes):
- Without patches: 314.9kB
- With patches: 49.4kB
I used minified sizes to make sure to compare comparable things.
