### PR TITLE
Properly working version of Java, including handling frames outside of user code and fixes to threads

### DIFF
--- a/Java_Dockerfile
+++ b/Java_Dockerfile
@@ -1,9 +1,12 @@
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
+
+RUN apk add --update --no-cache python3
 
 COPY ./java-debug /usr/project/java-debug
+RUN mkdir /usr/project/jdtls && cd /usr/project/jdtls && tar xfpv /usr/project/java-debug/jdt-language-server-1.29.0-202310261436.tar.gz
 RUN cd /usr/project/java-debug && ./mvnw clean install -U
 
-ENV ROOT=/usr/project/java-debug
+ENV ROOT=/usr/project/
 WORKDIR ${ROOT}
 
 CMD [""]

--- a/buildjava.sh
+++ b/buildjava.sh
@@ -1,0 +1,1 @@
+npm run build:java ; docker run -it -v /var/www/codecast-debuggers/jdtls/:/tmp/jdtls java-debugger cp /usr/project/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-0.50.0.jar /tmp/jdtls/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "recursive-diff": "^1.0.8",
         "tmp": "^0.2.1",
         "ts-command-line-args": "^2.2.1",
+        "ts-lsp-client": "^1.0.1",
         "ws": "^8.14.2"
       },
       "devDependencies": {
@@ -682,6 +683,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.3",
@@ -1696,6 +1702,100 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/args": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+      "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/args/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/args/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/args/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/args/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/args/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -1735,6 +1835,14 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -2447,6 +2555,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -2604,6 +2720,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
       }
     },
     "node_modules/dynamic-dedupe": {
@@ -3077,6 +3204,19 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -4331,6 +4471,22 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4433,6 +4589,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.0.tgz",
+      "integrity": "sha512-asnLgC1qD5ytP+fvBP8uL0rvj+l8P6iYICbzZ8dVxCpESffVjzA7KkYkbKCIbavs7cllwH1ZUaNtJwphdeRqpg=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4836,6 +4997,14 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4913,6 +5082,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -5100,6 +5274,71 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-5.1.3.tgz",
+      "integrity": "sha512-Zj+0TVdYKkAAIx9EUCL5e4TttwgsaFvJh2ceIMQeFCY8ak9tseEZQGSgpvyjEj1/iIVGIh5tdhkGEQWSMILKHA==",
+      "dependencies": {
+        "@hapi/bourne": "^2.0.0",
+        "args": "^5.0.1",
+        "chalk": "^4.0.0",
+        "dateformat": "^4.5.1",
+        "fast-safe-stringify": "^2.0.7",
+        "jmespath": "^0.15.0",
+        "joycon": "^3.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -5155,6 +5394,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -5213,6 +5457,11 @@
         }
       ]
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -5242,6 +5491,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/recursive-diff": {
@@ -5360,8 +5617,7 @@
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -5420,6 +5676,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5535,6 +5799,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5558,6 +5830,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -5602,6 +5882,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5705,7 +5990,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -5846,6 +6130,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -5989,6 +6281,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-lsp-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-lsp-client/-/ts-lsp-client-1.0.1.tgz",
+      "integrity": "sha512-7N9kn6uPSJKR5RA0Gala6Nyg9NtSG3Us9pjPJ6aFYDZ+Pm936M686084kaZDRFlvtt9VLM4oix4Lpu4tRlnj5Q==",
+      "dependencies": {
+        "json-rpc-2.0": "^1.6.0",
+        "pino": "^7.0.5",
+        "pino-pretty": "^5.1.3",
+        "tslib": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 14.21",
+        "pnpm": ">= 6.0.0"
+      }
+    },
+    "node_modules/ts-lsp-client/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/ts-node": {
       "version": "10.4.0",
@@ -7004,6 +7316,11 @@
         }
       }
     },
+    "@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -7802,6 +8119,78 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "args": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+      "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -7832,6 +8221,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -8365,6 +8759,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -8480,6 +8879,17 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
       }
     },
     "dynamic-dedupe": {
@@ -8847,6 +9257,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -9791,6 +10211,16 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
+    },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9861,6 +10291,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "json-rpc-2.0": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.0.tgz",
+      "integrity": "sha512-asnLgC1qD5ytP+fvBP8uL0rvj+l8P6iYICbzZ8dVxCpESffVjzA7KkYkbKCIbavs7cllwH1ZUaNtJwphdeRqpg=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -10162,6 +10597,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10229,6 +10669,11 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
       "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
+    },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "once": {
       "version": "1.4.0",
@@ -10362,6 +10807,67 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-pretty": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-5.1.3.tgz",
+      "integrity": "sha512-Zj+0TVdYKkAAIx9EUCL5e4TttwgsaFvJh2ceIMQeFCY8ak9tseEZQGSgpvyjEj1/iIVGIh5tdhkGEQWSMILKHA==",
+      "requires": {
+        "@hapi/bourne": "^2.0.0",
+        "args": "^5.0.1",
+        "chalk": "^4.0.0",
+        "dateformat": "^4.5.1",
+        "fast-safe-stringify": "^2.0.7",
+        "jmespath": "^0.15.0",
+        "joycon": "^3.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+    },
     "pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -10402,6 +10908,11 @@
         }
       }
     },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10439,6 +10950,11 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -10463,6 +10979,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
     "recursive-diff": {
       "version": "1.0.8",
@@ -10545,8 +11066,7 @@
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -10587,6 +11107,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -10668,6 +11193,14 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10688,6 +11221,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
+    },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -10722,6 +11260,11 @@
           "dev": true
         }
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -10794,8 +11337,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "supports-color": {
       "version": "7.2.0",
@@ -10900,6 +11442,14 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
+    },
     "throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -10992,6 +11542,24 @@
         "make-error": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
+      }
+    },
+    "ts-lsp-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-lsp-client/-/ts-lsp-client-1.0.1.tgz",
+      "integrity": "sha512-7N9kn6uPSJKR5RA0Gala6Nyg9NtSG3Us9pjPJ6aFYDZ+Pm936M686084kaZDRFlvtt9VLM4oix4Lpu4tRlnj5Q==",
+      "requires": {
+        "json-rpc-2.0": "^1.6.0",
+        "pino": "^7.0.5",
+        "pino-pretty": "^5.1.3",
+        "tslib": "~2.4.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "ts-node": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "recursive-diff": "^1.0.8",
     "tmp": "^0.2.1",
     "ts-command-line-args": "^2.2.1",
+    "ts-lsp-client": "^1.0.1",
     "ws": "^8.14.2"
   },
   "devDependencies": {

--- a/samples/java/add.java
+++ b/samples/java/add.java
@@ -1,0 +1,15 @@
+class HelloWorld {
+    public static int add(int a, int b) {
+        int c = a + b;
+        return c;
+    }
+    
+    public static void main(String[] args) {
+        int x = 5;
+        System.out.println("Hello, World!");
+        int y = 3;
+        int z = add(x, y);
+        System.out.println("Hello, World, again!");
+        System.out.println(z);
+    }
+}

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -67,7 +67,7 @@ export async function getSteps(commandOptions: CommandLineOptions): Promise<Step
 
     function onSnapshot(snapshot: StepSnapshot): void {
       steps.push(snapshot);
-      void runner?.stepOver();
+      void runner?.stepIn();
     }
 
     function onTerminate(message: TerminationMessage): void {

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -67,7 +67,7 @@ export async function getSteps(commandOptions: CommandLineOptions): Promise<Step
 
     function onSnapshot(snapshot: StepSnapshot): void {
       steps.push(snapshot);
-      void runner?.stepIn();
+      void runner?.stepOver();
     }
 
     function onTerminate(message: TerminationMessage): void {

--- a/src/run-steps/java-runner.ts
+++ b/src/run-steps/java-runner.ts
@@ -7,16 +7,18 @@ import { logger } from '../logger';
 import { Cleanable, makeRunner, MakeRunnerConfig, Runner, RunnerOptions } from './runner';
 import { Stream } from 'stream';
 import { config } from '../config';
+import { JSONRPCEndpoint, LspClient } from 'ts-lsp-client';
+import * as pty from 'node-pty';
 
 export const runStepsWithJavaDebugger = (options: RunnerOptions): Promise<Runner> => {
-  const compiledPath = path.join(config.sourcesPath, 'code-' + options.uid.toString() + '.java');
-  fs.writeFileSync(compiledPath, fs.readFileSync(options.main.relativePath, 'utf-8'));
+  const programPath = path.join(config.sourcesPath, 'code-' + options.uid.toString() + '.java');
+  fs.writeFileSync(programPath, fs.readFileSync(options.main.relativePath, 'utf-8'));
 
   const runner = makeRunner({
     connect,
   });
 
-  return runner({ ...options, main: { relativePath: compiledPath } } as RunnerOptions);
+  return runner({ ...options, main: { relativePath: programPath } } as RunnerOptions);
 };
 
 const connect: MakeRunnerConfig['connect'] = async ({ uid, cleanables, programPath, logLevel, onOutput, beforeInitialize, inputStream }) => {
@@ -26,10 +28,10 @@ const connect: MakeRunnerConfig['connect'] = async ({ uid, cleanables, programPa
     port: uid,
   };
 
-  const compiledPath = await compile(programPath, uid);
+  const compiledPath = await compile(programPath, uid, cleanables);
 
   logger.debug(1, '[Java StepsRunner] start adapter server');
-  await spawnDebugAdapterServer(dap, compiledPath, cleanables, inputStream);
+  await spawnDebugAdapterServer(dap, programPath, compiledPath, cleanables, inputStream);
 
   logger.debug(2, '[Java StepsRunner] instantiate SocketDebugClient');
   const client = new SocketDebugClient({
@@ -62,44 +64,114 @@ const connect: MakeRunnerConfig['connect'] = async ({ uid, cleanables, programPa
     pathFormat: 'path',
     supportsMemoryEvent: true,
     supportsMemoryReferences: true,
+    supportsRunInTerminalRequest: true,
+    supportsInvalidatedEvent: true,
+    supportsProgressReporting: true,
+    supportsVariablePaging: true,
+    supportsVariableType: true,
   });
 
   logger.debug('Initialize Response : ', initializeResponse);
 
+  const waitForRunInTerminal = new Promise<void>((resolve, reject) => {
+    client.onRunInTerminalRequest(({ args: [ argv, ...args ], cwd, env, kind, title }) => {
+      if (!argv) {
+        throw new Error('argv must be defined');
+      }
+      logger.debug('[Event] RunInTerminalRequest', { argv, args, cwd, env, kind, title });
+      const ritArgs = [
+        'docker', 'exec', '-it', 'java-' + uid.toString(),
+        '/opt/java/openjdk/bin/java',
+        ...args,
+      ];
+      logger.debug('[RIT args]', ritArgs);
+      const subprocess = pty.spawn(ritArgs[0] || '', ritArgs.slice(1), {
+      //const subprocess = pty.spawn(argv, args, {
+        name: title ?? 'reverse_command',
+        cols: 80,
+        rows: 1,
+        cwd,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        env: { ...env, RUST_BACKTRACE: 'full' },
+      });
+
+      subprocess.onData(message => {
+        logger.debug('[RIT]', message);
+        if (message == '\u001b[2J\u001b[1;1H') { // clear screen
+          return;
+        }
+        onOutput({
+          category: 'stdout',
+          // since pty adds a \n when emitting command output, remove one from the message
+          output: message.replace(/\n$/, ''),
+        });
+      });
+      subprocess.onExit(e => {
+        logger.debug('[on exit]', e);
+        if (e.exitCode > 0) {
+          reject(new Error(`Terminal request exited with code ${e.exitCode}`));
+        }
+      });
+      //subprocess.write(`${argv} ${args.join(' ')}\r`);
+
+      cleanables.push(subprocess);
+
+      logger.debug(7, '[Java StepsRunner] ran requested command in terminal');
+      setTimeout(resolve, 1000);
+
+      // subprocess.stdout.on('data', (data) => logger.debug('[stdout]', data.toString('utf-8')))
+      // subprocess.stderr.on('data', (data) => logger.debug('[stderr]', data.toString('utf-8')))
+      return Promise.resolve({ processId: subprocess.pid, shellProcessId: process.pid });
+    });
+  });
+
+
   logger.debug(6, '[Java StepsRunner] launch client', compiledPath);
   const launched = client.launch({
+    type: 'java',
     program: compiledPath,
-    mainClass: 'HelloWorld',
+    mainClass: path.basename(compiledPath, '.class'),
     classPaths: [ path.dirname(compiledPath) ],
-    justMyCode: false,
+    console: 'integratedTerminal',
+    internalConsoleOptions: 'neverOpen',
+    justMyCode: true,
+    noDebug: false,
   } as DebugProtocol.LaunchRequestArguments);
 
-  await Promise.race([
-    launched.then(response => {
-      logger.debug('[Java StepsRunner] launch response', response);
-    }),
-    initialized,
-  ]);
+  // await Promise.race([
+  //   launched.then(_response => {
+  //     logger.debug('[Java StepsRunner] launched');
+  //   }),
+  //   initialized,
+  // ]);
+  await initialized;
+  await launched;
+  await waitForRunInTerminal;
 
   return { client };
 };
 
 
-async function compile(programPath: string, uid: number): Promise<string> {
+async function compile(programPath: string, uid: number, cleanables: Cleanable[]): Promise<string> {
   // TODO :: handle compilation errors
+
   const compilationPath = path.join('/tmp', 'javac-' + uid.toString());
   fs.mkdirSync(compilationPath, { recursive: true });
+  cleanables.push({ path: compilationPath });
 
   const subprocessParams = [
     'docker',
     'run',
     '--rm',
+    '--name',
+    `java-${uid.toString()}-compile`,
     '-v',
     `${programPath}:${programPath}:ro`,
     '-v',
     `${compilationPath}:${compilationPath}`,
     'java-debugger',
     'javac',
+    '-g',
     '-d',
     compilationPath,
     programPath,
@@ -121,55 +193,81 @@ async function compile(programPath: string, uid: number): Promise<string> {
   logger.debug('Compiled Java', compiledFileName);
 
   // copy to sources folder
-  const compiledPath = path.join(config.sourcesPath, 'HelloWorld.class');
-  //const compiledPath = path.join(config.sourcesPath, 'code-' + uid.toString() + '.class');
+  const compiledPath = path.join(config.sourcesPath, compiledFileName);
   fs.copyFileSync(path.join(compilationPath, compiledFileName), compiledPath);
+  logger.debug('Copied Java', compiledPath);
 
   return compiledPath;
 }
 
 async function spawnDebugAdapterServer(
   dap: { host: string, port: number },
-  programPath: string,
+  _programPath: string,
+  _compiledPath: string,
   cleanables: Cleanable[],
-  inputStream: Stream|null,
+  _inputStream: Stream|null,
 ): Promise<void> {
-  return new Promise<void>(resolve => {
-    const subprocessParams = [
-      'docker',
-      'run',
-      '--rm',
-      '-v',
-      `${programPath}:${programPath}:ro`,
-      '-p',
-      `${dap.port.toString()}:4000`,
-      '--name',
-      'java-' + dap.port.toString(),
-      'java-debugger',
-      'java',
-      '-cp',
-      '.:/usr/project/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-0.50.0.jar:/root/.m2/repository/p2/osgi/bundle/com.google.gson/2.10.1.v20230109-0753/com.google.gson-2.10.1.v20230109-0753.jar:/root/.m2/repository/com/google/guava/guava/32.1.3-jre/guava-32.1.3-jre.jar:/root/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/root/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/root/.m2/repository/org/checkerframework/checker-qual/3.37.0/checker-qual-3.37.0.jar:/root/.m2/repository/com/google/errorprone/error_prone_annotations/2.21.1/error_prone_annotations-2.21.1.jar:/root/.m2/repository/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar:/root/.m2/repository/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar:/usr/project/java-debug/com.microsoft.java.debug.plugin/lib/commons-io-2.11.0.jar:/usr/project/java-debug/com.microsoft.java.debug.plugin/lib/rxjava-2.2.21.jar:/usr/project/java-debug/com.microsoft.java.debug.plugin/lib/reactive-streams-1.0.4.jar:/usr/project/java-debug/com.microsoft.java.debug.plugin/lib/com.microsoft.java.debug.core-0.50.0.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.runtime/3.30.0.v20231102-0719/org.eclipse.core.runtime-3.30.0.v20231102-0719.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.debug.core/3.21.200.v20231021-1513/org.eclipse.debug.core-3.21.200.v20231021-1513.jar:/root/.m2/repository/.cache/tycho/org.eclipse.jdt.debug-3.21.200.v20231103-0755.jar/jdimodel.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.core/3.36.0.v20231108-0715/org.eclipse.jdt.core-3.36.0.v20231108-0715.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.core.manipulation/1.20.0.v20231106-1537/org.eclipse.jdt.core.manipulation-1.20.0.v20231106-1537.jar:/root/.m2/repository/.cache/tycho/org.eclipse.jdt.ls.core-1.30.0.202311221951.jar/lib/jsoup-1.14.2.jar:/root/.m2/repository/.cache/tycho/org.eclipse.jdt.ls.core-1.30.0.202311221951.jar/lib/remark-1.2.0.jar:/root/.m2/repository/.cache/tycho/org.eclipse.jdt.ls.core-1.30.0.202311221951.jar/lib/java-decompiler-engine-231.9011.34.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.ls.core/1.30.0.202311221951/org.eclipse.jdt.ls.core-1.30.0.202311221951.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.launching/3.21.0.v20231103-0759/org.eclipse.jdt.launching-3.21.0.v20231103-0759.jar:/root/.m2/repository/org/apache/commons/commons-lang3/3.13.0/commons-lang3-3.13.0.jar:/root/.m2/repository/org/eclipse/lsp4j/org.eclipse.lsp4j/0.21.0/org.eclipse.lsp4j-0.21.0.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.osgi/3.18.600.v20231106-1816/org.eclipse.osgi-3.18.600.v20231106-1816.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-antlr.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-bcel.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-bsf.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-log4j.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-oro.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-regexp.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-resolver.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-apache-xalan2.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-commons-logging.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-commons-net.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-imageio.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-jakartamail.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-javamail.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-jdepend.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-jmf.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-jsch.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-junit.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-junit4.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-junitlauncher.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-launcher.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-netrexx.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-swing.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-testutil.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant-xz.jar:/root/.m2/repository/.cache/tycho/org.apache.ant-1.10.14.v20230922-1200.jar/lib/ant.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.commands/3.11.200.v20231108-1058/org.eclipse.core.commands-3.11.200.v20231108-1058.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.equinox.common/3.18.200.v20231106-1826/org.eclipse.equinox.common-3.18.200.v20231106-1826.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.contenttype/3.9.200.v20230914-0751/org.eclipse.core.contenttype-3.9.200.v20230914-0751.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.equinox.preferences/3.10.400.v20231102-2218/org.eclipse.equinox.preferences-3.10.400.v20231102-2218.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.equinox.registry/3.11.400.v20231102-2218/org.eclipse.equinox.registry-3.11.400.v20231102-2218.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.expressions/3.9.200.v20230921-0857/org.eclipse.core.expressions-3.9.200.v20230921-0857.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.filebuffers/3.8.200.v20230921-0933/org.eclipse.core.filebuffers-3.8.200.v20230921-0933.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.text/3.13.100.v20230801-1334/org.eclipse.text-3.13.100.v20230801-1334.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.filesystem/1.10.200.v20231102-0934/org.eclipse.core.filesystem-1.10.200.v20231102-0934.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.jobs/3.15.100.v20230930-1207/org.eclipse.core.jobs-3.15.100.v20230930-1207.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.net/1.5.200.v20231106-1240/org.eclipse.core.net-1.5.200.v20231106-1240.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.equinox.security/1.4.100.v20231012-1825/org.eclipse.equinox.security-1.4.100.v20231012-1825.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.resources/3.20.0.v20231102-0934/org.eclipse.core.resources-3.20.0.v20231102-0934.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.equinox.app/1.6.400.v20231103-0807/org.eclipse.equinox.app-1.6.400.v20231103-0807.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.core.variables/3.6.200.v20230914-0751/org.eclipse.core.variables-3.6.200.v20230914-0751.jar:/root/.m2/repository/org/osgi/org.osgi.service.prefs/1.1.2/org.osgi.service.prefs-1.1.2.jar:/root/.m2/repository/org/osgi/osgi.annotation/8.0.1/osgi.annotation-8.0.1.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.apt.core/3.8.200.v20231108-0715/org.eclipse.jdt.apt.core-3.8.200.v20231108-0715.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.jdt.core.compiler.batch/3.36.0.v20231108-0715/org.eclipse.jdt.core.compiler.batch-3.36.0.v20231108-0715.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.ltk.core.refactoring/3.14.200.v20231106-1218/org.eclipse.ltk.core.refactoring-3.14.200.v20231106-1218.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.search.core/3.16.0.v20230921-0933/org.eclipse.search.core-3.16.0.v20230921-0933.jar:/root/.m2/repository/org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.21.0/org.eclipse.lsp4j.jsonrpc-0.21.0.jar:/root/.m2/repository/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar:/root/.m2/repository/p2/osgi/bundle/org.eclipse.xtext.xbase.lib/2.33.0.v20231112-1245/org.eclipse.xtext.xbase.lib-2.33.0.v20231112-1245.jar',
-      'com/microsoft/java/debug/plugin/internal/JavaDebugServer',
-    ];
-
-    logger.log('Spawn Java', subprocessParams);
-    logger.log('cmdline', subprocessParams.join(' '));
-
-    const subprocess = cp.spawn(subprocessParams[0] as string, subprocessParams.slice(1), {
-      stdio: [ (inputStream) ? inputStream : 'ignore', 'pipe', 'pipe' ],
-    });
-    cleanables.push(subprocess);
-
-    const onMessage = (origin: string) => (data: Buffer) => {
-      const message = data.toString('utf-8');
-      logger.debug('[Java DAP]', origin, message);
-    };
-    subprocess.stdout.on('data', onMessage('stdout'));
-    subprocess.stderr.on('data', onMessage('stderr'));
-    // We have no way of knowing when it actually starts listening
-    // TODO :: maybe modify the server to output something when it's ready?
-    setTimeout(() => resolve(), 1000);
-
-    subprocess.on('error', error => logger.error('Server error:', error));
+  // To spawn the DAP server, we need to spawn the Eclipse JDT LS
+  const lspSubprocess = [
+    'docker',
+    'run',
+    '-i',
+    '--rm',
+    '--name',
+    `java-${dap.port.toString()}`,
+    '-p',
+    `${dap.port}:4000`,
+    '-v',
+    `${config.sourcesPath}:${config.sourcesPath}`,
+    'java-debugger',
+    '/usr/project/jdtls/bin/jdtls',
+    '-configuration',
+    '/usr/project/jdtls/config_linux',
+    '-data',
+    '/usr/project/jdtls/data',
+  ];
+  const subprocess = cp.spawn(lspSubprocess[0] as string, lspSubprocess.slice(1), {
+    stdio: 'pipe',
   });
+  cleanables.push(subprocess);
+  logger.debug('Spawned LSP server');
+
+  // subprocess.stdout.on('data', (data: Buffer) => {
+  //   logger.debug('[LSP stdout]', data.toString('utf-8'));
+  // });
+  subprocess.stderr.on('data', (data: Buffer) => {
+    logger.debug('[LSP stderr]', data.toString('utf-8'));
+  });
+
+
+  const endpoint = new JSONRPCEndpoint(subprocess.stdin, subprocess.stdout);
+  // Note : the LSP client is not used that much, we could maybe get rid of that dependency and just communicate with the endpoint
+  const client = new LspClient(endpoint);
+
+  // Ask to initialize with the java-debug plugin
+  const initResult = await client.initialize({
+    processId: subprocess.pid || 0,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: null,
+    initializationOptions: {
+      bundles: [ '/usr/project/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-0.50.0.jar' ],
+    },
+  });
+  // const initResult = await endpoint.send('initialize', {
+  //   processId: subprocess.pid || 0,
+  //   rootUri: null,
+  //   capabilities: {},
+  //   workspaceFolders: null,
+  //   initializationOptions: {
+  //     bundles: [ '/usr/project/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-0.49.0.jar' ],
+  //   },
+  // }) as unknown;
+  logger.debug('LSP Initialized', initResult);
+
+  // Send a raw command to start the debug session
+  const dapPort = await endpoint.send('workspace/executeCommand', {
+    command: 'vscode.java.startDebugSession',
+  }) as number;
+  logger.debug('LSP Debug Session Started', dapPort);
 }

--- a/src/run-steps/runner.ts
+++ b/src/run-steps/runner.ts
@@ -294,6 +294,8 @@ export const makeRunner = ({
     // send 'configuration done' (in some debuggers this will trigger 'continue' if attach was awaited)
     await client.configurationDone({});
 
+    logger.debug(4, '[runner] Runner ready');
+
     function setSpeed(newSpeed?: number): void {
       speed = Math.max(1, Math.floor(newSpeed || 1));
     }
@@ -461,7 +463,6 @@ const registerEvents = (client: SocketDebugClient, onTerminated: (exitCode?: num
 
   client.onThread(thread => {
     logger.debug('[Event] Thread', thread);
-    void client.pause({ threadId: thread.threadId });
   });
 };
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,6 +1,7 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { RunStepContext } from './run-steps/runner';
 import { logger } from './logger';
+import path from 'path';
 
 export type StepsAcc = StepSnapshot[];
 
@@ -215,5 +216,5 @@ async function getVariable(
 
 function isKeepableStackFrame(canDigStackFrame: (stackFrame: DebugProtocol.StackFrame) => boolean, fileAbsolutePaths: string[]) {
   return (stackFrame: DebugProtocol.StackFrame): boolean =>
-    canDigStackFrame(stackFrame) && !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path);
+    canDigStackFrame(stackFrame) && !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path || path.basename(filePath) === stackFrame.source?.path);
 }

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -6,7 +6,7 @@ import path from 'path';
 export type StepsAcc = StepSnapshot[];
 
 export interface StepSnapshot {
-  stackFrames?: StackFrame[],
+  stackFrames?: StackFrameSnapshot[],
   stdout?: string[],
   stderr?: string[],
   terminated?: boolean,
@@ -18,20 +18,25 @@ export interface TerminationMessage {
   message: string,
 }
 
-export interface StackFrame extends DebugProtocol.StackFrame {
-  scopes: Scope[],
+export interface StackFrameSnapshot extends DebugProtocol.StackFrame {
+  scopes: ScopeSnapshot[],
+
+  /**
+   * Whether this stack frame is a "user frame", both within a user file and diggable
+   */
+  userFrame?: boolean,
 }
-export interface Scope extends DebugProtocol.Scope {
+export interface ScopeSnapshot extends DebugProtocol.Scope {
   variables: (string | DebugProtocol.Variable)[],
   variableDetails: VariableHashMap,
 }
-export interface Variable extends DebugProtocol.Variable {
+export interface VariableSnapshot extends DebugProtocol.Variable {
   variables: (string | DebugProtocol.Variable)[],
   memory?: DebugProtocol.ReadMemoryResponse['body'],
 }
 
 interface VariableHashMap {
-  [reference: string]: Variable,
+  [reference: string]: VariableSnapshot,
 }
 
 interface VariableResultHashMap {
@@ -64,13 +69,17 @@ interface GetSnapshotParams {
 
 export async function getSnapshot({ context, filePaths, threadId, fullSnapshot }: GetSnapshotParams): Promise<StepSnapshot> {
   const result = await context.client.stackTrace({ threadId });
-  const keepableStackFrames = result.stackFrames.filter(isKeepableStackFrame(context.canDigStackFrame, filePaths));
+  const stackFrames: StackFrameSnapshot[] = result.stackFrames.map(
+    (frame: DebugProtocol.StackFrame) =>
+      ({ ...frame, scopes: [], userFrame: isUserStackFrame(context.canDigStackFrame, filePaths, frame) })
+  );
   if (fullSnapshot) {
     return { stackFrames: await Promise.all(
-      keepableStackFrames.map(stackFrame => getStackFrame({ context, stackFrame }))
+      // only dig user stack frames
+      stackFrames.map(stackFrame => (stackFrame.userFrame ? getStackFrame({ context, stackFrame }) : Promise.resolve(stackFrame)))
     ) };
   } else {
-    return { stackFrames: keepableStackFrames.map(stackFrame => ({ ...stackFrame, scopes: [] })) };
+    return { stackFrames };
   }
 }
 
@@ -79,7 +88,7 @@ interface GetStackFrameParams {
     context: RunStepContext,
 }
 
-async function getStackFrame({ context, stackFrame }: GetStackFrameParams): Promise<StackFrame> {
+async function getStackFrame({ context, stackFrame }: GetStackFrameParams): Promise<StackFrameSnapshot> {
   /*if (!isKeepableStackFrame(context.canDigStackFrame, filePaths)(stackFrame)) {
     return { ...stackFrame, scopes: [] };
   }*/
@@ -94,7 +103,7 @@ interface GetScopeParams {
     context: RunStepContext,
 }
 
-async function getScope({ context, scope }: GetScopeParams): Promise<Scope> {
+async function getScope({ context, scope }: GetScopeParams): Promise<ScopeSnapshot> {
   if (!context.canDigScope(scope)) {
     return {
       ...scope,
@@ -214,7 +223,6 @@ async function getVariable(
   }
 }
 
-function isKeepableStackFrame(canDigStackFrame: (stackFrame: DebugProtocol.StackFrame) => boolean, fileAbsolutePaths: string[]) {
-  return (stackFrame: DebugProtocol.StackFrame): boolean =>
-    canDigStackFrame(stackFrame) && !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path || path.basename(filePath) === stackFrame.source?.path);
+function isUserStackFrame(canDigStackFrame: (stackFrame: DebugProtocol.StackFrame) => boolean, fileAbsolutePaths: string[], stackFrame: DebugProtocol.StackFrame): boolean {
+  return canDigStackFrame(stackFrame) && !!stackFrame.source && fileAbsolutePaths.some(filePath => filePath === stackFrame.source?.path || path.basename(filePath) === stackFrame.source?.path);
 }


### PR DESCRIPTION
This version makes Java work properly with all current debugger features. The previous version only supported somewhat executing a file and getting its output, but breakpoints wouldn't work.
* Used Eclipse JDT Language Server so the java-debug plugin features work properly.
* Modified to java-debug to return the source code name all the time (issue source is unknown, might happen because we don't fully use the LS properly)
* Fixed thread management as lastThreadId would end up being the wrong thread in Java
* Handled stackFrames outside of user code properly, as in Java that would happen all the time

That last modification should also help all languages and avoid issues when entering an outside library.
